### PR TITLE
fix unsigned-signed int narrowing warnings

### DIFF
--- a/libfovis/libfovis/rectification.hpp
+++ b/libfovis/libfovis/rectification.hpp
@@ -142,7 +142,7 @@ class Rectification
         wright * wbottom
       };
 
-      int ra_index = v * _input_camera.width + u;
+      uint32_t ra_index = v * _input_camera.width + u;
       uint32_t neighbor_indices[4] = {
         ra_index,
         ra_index + 1,


### PR DESCRIPTION
Compiler complains that assigning `int` data to `uint32_t` data structure might cause data loss. 

This PR fixes that by defining `ra_index` as `uint32_t` instead.

Note that `u` and `v` are checked beforehand so the assignment is safe.
